### PR TITLE
Add nfma<mode>4_unsafe and nfms<mode>4_unsafe pattern

### DIFF
--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -846,6 +846,30 @@
   [(set_attr "type" "fmadd")
    (set_attr "mode" "<UNITMODE>")])
 
+;; Distributive law: -((a * b) + c) -> -a * b - c
+(define_insn "nfma<mode>4_dist"
+  [(set (match_operand:ANYF 0 "register_operand" "=f")
+    (fma:ANYF
+      (neg:ANYF (match_operand:ANYF 1 "register_operand" "f"))
+      (match_operand:ANYF 2 "register_operand" "f")
+      (neg:ANYF (match_operand:ANYF 3 "register_operand" "f"))))]
+  "TARGET_HARD_FLOAT"
+  "fnmadd.<fmt>\t%0,%1,%2,%3"
+  [(set_attr "type" "fmadd")
+   (set_attr "mode" "<UNITMODE>")])
+
+;; Distributive law: -((a * b) - c) -> -a * b + c
+(define_insn "nfms<mode>4_dist"
+  [(set (match_operand:ANYF 0 "register_operand" "=f")
+    (fma:ANYF
+      (neg:ANYF (match_operand:ANYF 1 "register_operand" "f"))
+      (match_operand:ANYF 2 "register_operand" "f")
+      (match_operand:ANYF 3 "register_operand" "f")))]
+  "TARGET_HARD_FLOAT"
+  "fnmsub.<fmt>\t%0,%1,%2,%3"
+  [(set_attr "type" "fmadd")
+   (set_attr "mode" "<UNITMODE>")])
+
 ;; modulo signed zeros, -(a*b+c) == -c-a*b
 (define_insn "*nfma<mode>4_fastmath"
   [(set (match_operand:ANYF 0 "register_operand" "=f")


### PR DESCRIPTION
This patch was hold in my branch for few days, I just not sure does it need guard by fast-math or not, however I've read https://groups.google.com/a/groups.riscv.org/forum/#!msg/sw-dev/795mx1ZQNFY/-LmhAJzIFwAJ this thread, so... @aswaterman do you think we just match this pattern without -ffast-math?
and this patch can fix the issue https://github.com/riscv/riscv-gnu-toolchain/issues/211 .