### PR TITLE
Back-port from trunk to 8.2.0

### DIFF
--- a/gcc/ChangeLog
+++ b/gcc/ChangeLog
@@ -1,3 +1,7 @@
+2018-09-26  Jim Wilson  <jimw@sifive.com>
+
+	* config/riscv/riscv.h (FUNCTION_ARG_REGNO_P): Fix comment.
+
 2018-09-25  Jim Wilson  <jimw@sifive.com>
 
 	* config/riscv/riscv.c (riscv_split_symbol): Mark auipc label as weak

--- a/gcc/ChangeLog
+++ b/gcc/ChangeLog
@@ -1,3 +1,8 @@
+2018-10-03  Jim Wilson  <jimw@sifive.com>
+
+	* config/riscv/riscv-c.c (riscv_cpu_cpp_builtins): For ABI_ILP32E,
+	also define __riscv_abi_rve.  Delete trailing white space.
+
 2018-09-26  Jim Wilson  <jimw@sifive.com>
 
 	* config/riscv/riscv.md (subsi3_extended2): Add J constraint.

--- a/gcc/ChangeLog
+++ b/gcc/ChangeLog
@@ -1,3 +1,10 @@
+2018-10-05  Andrew Waterman  <andrew@sifive.com>
+	    Jim Wilson  <jimw@sifive.com>
+
+	* config/riscv/riscv.md (f<quiet_pattern>_quiet<ANYF:mode><X:mode>4):
+	Add define_expand.  Add ! HONOR_SNANS check to current pattern.  Add
+	new pattern using HONOR_SNANS that emits one extra instruction.
+
 2018-10-03  Jim Wilson  <jimw@sifive.com>
 
 	* config/riscv/riscv-c.c (riscv_cpu_cpp_builtins): For ABI_ILP32E,

--- a/gcc/ChangeLog
+++ b/gcc/ChangeLog
@@ -1,5 +1,10 @@
 2018-09-26  Jim Wilson  <jimw@sifive.com>
 
+	* config/riscv/riscv.md (subsi3_extended2): Add J constraint.
+	(negdi2, negsi2, negsi2_extended, negsi2_extended2): New.
+
+2018-09-26  Jim Wilson  <jimw@sifive.com>
+
 	* config/riscv/riscv.h (FUNCTION_ARG_REGNO_P): Fix comment.
 
 2018-09-25  Jim Wilson  <jimw@sifive.com>

--- a/gcc/ChangeLog
+++ b/gcc/ChangeLog
@@ -1,3 +1,10 @@
+2018-09-24  Jim Wilson  <jimw@sifive.com>
+
+	PR target/87391
+	* config/riscv/riscv.h (STACK_BOUNDARY): Test riscv_abi == ABI_ILP32E
+	not TARGET_RVE.
+	(ABI_STACK_BOUNDARY, MAX_ARGS_IN_REGISTERS): Likewise.
+
 2018-07-14  Jim Wilson  <jimw@sifive.com>
 
 	* config/riscv/linux.h (TARGET_ASM_FILE_END): New.

--- a/gcc/ChangeLog
+++ b/gcc/ChangeLog
@@ -1,3 +1,8 @@
+2018-09-25  Jim Wilson  <jimw@sifive.com>
+
+	* config/riscv/riscv.c (riscv_split_symbol): Mark auipc label as weak
+	when target symbol is weak.
+
 2018-09-24  Jim Wilson  <jimw@sifive.com>
 
 	PR target/87391

--- a/gcc/config/riscv/riscv-c.c
+++ b/gcc/config/riscv/riscv-c.c
@@ -35,62 +35,65 @@ void
 riscv_cpu_cpp_builtins (cpp_reader *pfile)
 {
   builtin_define ("__riscv");
-  
+
   if (TARGET_RVC)
     builtin_define ("__riscv_compressed");
-  
+
   if (TARGET_RVE)
     builtin_define ("__riscv_32e");
 
   if (TARGET_ATOMIC)
     builtin_define ("__riscv_atomic");
-  
+
   if (TARGET_MUL)
     builtin_define ("__riscv_mul");
   if (TARGET_DIV)
     builtin_define ("__riscv_div");
   if (TARGET_DIV && TARGET_MUL)
     builtin_define ("__riscv_muldiv");
-  
+
   builtin_define_with_int_value ("__riscv_xlen", UNITS_PER_WORD * 8);
   if (TARGET_HARD_FLOAT)
     builtin_define_with_int_value ("__riscv_flen", UNITS_PER_FP_REG * 8);
-  
+
   if (TARGET_HARD_FLOAT && TARGET_FDIV)
     {
       builtin_define ("__riscv_fdiv");
       builtin_define ("__riscv_fsqrt");
     }
-  
+
   switch (riscv_abi)
     {
-    case ABI_ILP32:
     case ABI_ILP32E:
+      builtin_define ("__riscv_abi_rve");
+      gcc_fallthrough ();
+
+    case ABI_ILP32:
     case ABI_LP64:
       builtin_define ("__riscv_float_abi_soft");
       break;
-  
+
     case ABI_ILP32F:
     case ABI_LP64F:
       builtin_define ("__riscv_float_abi_single");
       break;
-  
+
     case ABI_ILP32D:
     case ABI_LP64D:
       builtin_define ("__riscv_float_abi_double");
       break;
     }
-  
+
   switch (riscv_cmodel)
     {
     case CM_MEDLOW:
       builtin_define ("__riscv_cmodel_medlow");
       break;
-  
+
     case CM_MEDANY:
       builtin_define ("__riscv_cmodel_medany");
       break;
-  
+
     case CM_PIC:
       builtin_define ("__riscv_cmodel_pic");
       break;

--- a/gcc/config/riscv/riscv.c
+++ b/gcc/config/riscv/riscv.c
@@ -1097,6 +1097,11 @@ riscv_split_symbol (rtx temp, rtx addr, machine_mode mode, rtx *low_out)
 
 	  label = gen_rtx_SYMBOL_REF (Pmode, ggc_strdup (buf));
 	  SYMBOL_REF_FLAGS (label) |= SYMBOL_FLAG_LOCAL;
+	  /* ??? Ugly hack to make weak symbols work.  May need to change the
+	     RTL for the auipc and/or low patterns to get a better fix for
+	     this.  */
+	  if (! nonzero_address_p (addr))
+	    SYMBOL_REF_WEAK (label) = 1;
 
 	  if (temp == NULL)
 	    temp = gen_reg_rtx (Pmode);

--- a/gcc/config/riscv/riscv.h
+++ b/gcc/config/riscv/riscv.h
@@ -516,8 +516,7 @@ enum reg_class
 #define FUNCTION_VALUE_REGNO_P(N) ((N) == GP_RETURN || (N) == FP_RETURN)
 
 /* 1 if N is a possible register number for function argument passing.
-   We have no FP argument registers when soft-float.  When FP registers
-   are 32 bits, we can't directly reference the odd numbered ones.  */
+   We have no FP argument registers when soft-float.  */
 
 /* Accept arguments in a0-a7, and in fa0-fa7 if permitted by the ABI.  */
 #define FUNCTION_ARG_REGNO_P(N)						\

--- a/gcc/config/riscv/riscv.h
+++ b/gcc/config/riscv/riscv.h
@@ -126,10 +126,11 @@ along with GCC; see the file COPYING3.  If not see
 #define FUNCTION_BOUNDARY (TARGET_RVC ? 16 : 32)
 
 /* The smallest supported stack boundary the calling convention supports.  */
-#define STACK_BOUNDARY (TARGET_RVE ? BITS_PER_WORD : 2 * BITS_PER_WORD)
+#define STACK_BOUNDARY \
+  (riscv_abi == ABI_ILP32E ? BITS_PER_WORD : 2 * BITS_PER_WORD)
 
 /* The ABI stack alignment.  */
-#define ABI_STACK_BOUNDARY (TARGET_RVE ? BITS_PER_WORD : 128)
+#define ABI_STACK_BOUNDARY (riscv_abi == ABI_ILP32E ? BITS_PER_WORD : 128)
 
 /* There is no point aligning anything to a rounder boundary than this.  */
 #define BIGGEST_ALIGNMENT 128
@@ -492,7 +493,7 @@ enum reg_class
 #define GP_RETURN GP_ARG_FIRST
 #define FP_RETURN (UNITS_PER_FP_ARG == 0 ? GP_RETURN : FP_ARG_FIRST)
 
-#define MAX_ARGS_IN_REGISTERS (TARGET_RVE ? 6 : 8)
+#define MAX_ARGS_IN_REGISTERS (riscv_abi == ABI_ILP32E ? 6 : 8)
 
 /* Symbolic macros for the first/last argument registers.  */
 

--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -504,13 +504,48 @@
    (set_attr "mode" "SI")])
 
 (define_insn "*subsi3_extended2"
-  [(set (match_operand:DI                        0 "register_operand" "=r")
+  [(set (match_operand:DI                        0 "register_operand" "= r")
 	(sign_extend:DI
-	  (subreg:SI (minus:DI (match_operand:DI 1 "reg_or_0_operand" " r")
-			       (match_operand:DI 2 "register_operand" " r"))
+	  (subreg:SI (minus:DI (match_operand:DI 1 "reg_or_0_operand" " rJ")
+			       (match_operand:DI 2 "register_operand" "  r"))
 		     0)))]
   "TARGET_64BIT"
   "subw\t%0,%z1,%2"
+  [(set_attr "type" "arith")
+   (set_attr "mode" "SI")])
+
+(define_insn "negdi2"
+  [(set (match_operand:DI         0 "register_operand" "=r")
+	(neg:DI (match_operand:DI 1 "register_operand" " r")))]
+  "TARGET_64BIT"
+  "neg\t%0,%1"
+  [(set_attr "type" "arith")
+   (set_attr "mode" "DI")])
+
+(define_insn "negsi2"
+  [(set (match_operand:SI         0 "register_operand" "=r")
+	(neg:SI (match_operand:SI 1 "register_operand" " r")))]
+  ""
+  { return TARGET_64BIT ? "negw\t%0,%1" : "neg\t%0,%1"; }
+  [(set_attr "type" "arith")
+   (set_attr "mode" "SI")])
+
+(define_insn "*negsi2_extended"
+  [(set (match_operand:DI          0 "register_operand" "=r")
+	(sign_extend:DI
+	 (neg:SI (match_operand:SI 1 "register_operand" " r"))))]
+  "TARGET_64BIT"
+  "negw\t%0,%1"
+  [(set_attr "type" "arith")
+   (set_attr "mode" "SI")])
+
+(define_insn "*negsi2_extended2"
+  [(set (match_operand:DI                     0 "register_operand" "=r")
+	(sign_extend:DI
+	 (subreg:SI (neg:DI (match_operand:DI 1 "register_operand" " r"))
+	 	    0)))]
+  "TARGET_64BIT"
+  "negw\t%0,%1"
   [(set_attr "type" "arith")
    (set_attr "mode" "SI")])
 

--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -1947,18 +1947,40 @@
   [(set_attr "type" "fcmp")
    (set_attr "mode" "<UNITMODE>")])
 
-(define_insn "f<quiet_pattern>_quiet<ANYF:mode><X:mode>4"
-   [(set (match_operand:X         0 "register_operand" "=r")
+(define_expand "f<quiet_pattern>_quiet<ANYF:mode><X:mode>4"
+   [(parallel [(set (match_operand:X      0 "register_operand")
+		    (unspec:X
+		     [(match_operand:ANYF 1 "register_operand")
+		      (match_operand:ANYF 2 "register_operand")]
+		     QUIET_COMPARISON))
+	       (clobber (match_scratch:X 3))])]
+  "TARGET_HARD_FLOAT")
+
+(define_insn "*f<quiet_pattern>_quiet<ANYF:mode><X:mode>4_default"
+   [(set (match_operand:X      0 "register_operand" "=r")
 	 (unspec:X
-	     [(match_operand:ANYF 1 "register_operand" " f")
-	      (match_operand:ANYF 2 "register_operand" " f")]
-	     QUIET_COMPARISON))
+	  [(match_operand:ANYF 1 "register_operand" " f")
+	   (match_operand:ANYF 2 "register_operand" " f")]
+	  QUIET_COMPARISON))
     (clobber (match_scratch:X 3 "=&r"))]
-  "TARGET_HARD_FLOAT"
+  "TARGET_HARD_FLOAT && ! HONOR_SNANS (<ANYF:MODE>mode)"
   "frflags\t%3\n\tf<quiet_pattern>.<fmt>\t%0,%1,%2\n\tfsflags %3"
   [(set_attr "type" "fcmp")
    (set_attr "mode" "<UNITMODE>")
    (set (attr "length") (const_int 12))])
+
+(define_insn "*f<quiet_pattern>_quiet<ANYF:mode><X:mode>4_snan"
+   [(set (match_operand:X      0 "register_operand" "=r")
+	 (unspec:X
+	  [(match_operand:ANYF 1 "register_operand" " f")
+	   (match_operand:ANYF 2 "register_operand" " f")]
+	  QUIET_COMPARISON))
+    (clobber (match_scratch:X 3 "=&r"))]
+  "TARGET_HARD_FLOAT && HONOR_SNANS (<ANYF:MODE>mode)"
+  "frflags\t%3\n\tf<quiet_pattern>.<fmt>\t%0,%1,%2\n\tfsflags %3\n\tfeq.<fmt>\tzero,%1,%2"
+  [(set_attr "type" "fcmp")
+   (set_attr "mode" "<UNITMODE>")
+   (set (attr "length") (const_int 16))])
 
 (define_insn "*seq_zero_<X:mode><GPR:mode>"
   [(set (match_operand:GPR       0 "register_operand" "=r")

--- a/gcc/testsuite/ChangeLog
+++ b/gcc/testsuite/ChangeLog
@@ -1,3 +1,7 @@
+2018-09-25  Jim Wilson  <jimw@sifive.com>
+
+	* gcc.target/riscv/weak-1.c: New.
+
 2018-07-12  Kito Cheng  <kito.cheng@gmail.com>
 
         * gcc.target/riscv/interrupt-conflict-mode.c: New.

--- a/gcc/testsuite/gcc.target/riscv/weak-1.c
+++ b/gcc/testsuite/gcc.target/riscv/weak-1.c
@@ -1,0 +1,14 @@
+/* { dg-do compile } */
+/* { dg-options "-mcmodel=medany -mexplicit-relocs -O" } */
+
+/* Verify that the branch doesn't get optimized away.  */
+extern int weak_func(void) __attribute__ ((weak));
+
+int
+sub (void)
+{
+  if (weak_func)
+    return weak_func ();
+  return 0;
+}
+/* { dg-final { scan-assembler "b\(ne|eq\)" } } */


### PR DESCRIPTION
Back-port list:
- RISC-V: Fix -fsignaling-nans for glibc testsuite.
- RISC-V: Add macro for ilp32e ABI.  Cleanup white space.
- RISC-V: Add missing negate patterns.
- RISC-V: Delete obsolete MIPS comment.
- RISC-V: Fix weak symbols with medany and explicit relocs.
- RISC-V: Fix problems with ilp32e ABI support.

Tested with RV32GC and RV64GC.