### PR TITLE
Add range checking for vget/vset

### DIFF
--- a/gcc/config/riscv/vector.md
+++ b/gcc/config/riscv/vector.md
@@ -11131,7 +11131,7 @@
   "TARGET_VECTOR"
 {
   if (INTVAL (operands[3]) < 0
-      || (INTVAL (operands[3]) > riscv_get_nf (<MODE>mode)))
+      || (INTVAL (operands[3]) >= riscv_get_nf (<MODE>mode)))
     {
       gcc_unreachable ();
       FAIL;
@@ -11151,7 +11151,7 @@
   "TARGET_VECTOR"
 {
   if (INTVAL (operands[2]) < 0
-      || (INTVAL (operands[2]) > riscv_get_nf (<MODE>mode)))
+      || (INTVAL (operands[2]) >= riscv_get_nf (<MODE>mode)))
     {
       gcc_unreachable ();
       FAIL;
@@ -11301,6 +11301,11 @@
   poly_int64 offset = INTVAL (operands[2]) * GET_MODE_SIZE (GET_MODE (operands[0]));
   rtx subreg = simplify_gen_subreg (GET_MODE (operands[0]), operands[1],
 				    <MODE>mode, offset);
+  if(!subreg)
+    {
+      gcc_unreachable ();
+      FAIL;
+    }
   emit_move_insn (operands[0], subreg);
   DONE;
 })

--- a/gcc/testsuite/gcc.target/riscv/rvv/rvv-vget-vset.c
+++ b/gcc/testsuite/gcc.target/riscv/rvv/rvv-vget-vset.c
@@ -1,0 +1,27 @@
+/* { dg-do compile } */
+
+#include <riscv_vector.h>
+
+vint32m1_t vget (vint32m2_t data)
+{
+  return vget_v_i32m2_i32m1 (data, 2);
+  /* { dg-error "index 2 is out of range, should be less than 2." "" { target *-*-* } 0 } */
+}
+
+vint32m1_t vget_tuple (vint32m1x4_t data)
+{
+  return vget_i32m1x4_i32m1 (data, 4);
+  /* { dg-error "index 4 is out of range, should be less than 4." "" { target *-*-* } 0 } */
+}
+
+vint32m8_t vset (vint32m8_t data, vint32m1_t v)
+{
+  return vset_v_i32m1_i32m8 (data, 8, v);
+  /* { dg-error "index 8 is out of range, should be less than 8." "" { target *-*-* } 0 } */
+}
+
+vint32m1x8_t vset_tuple (vint32m1x8_t data, vint32m1_t v)
+{
+  return vset_i32m1x8 (data, 9, v);
+  /* { dg-error "index 9 is out of range, should be less than 8." "" { target *-*-* } 0 } */
+}


### PR DESCRIPTION
Add checker to `riscv_builtin_description` so that we can do some static semantic checking for builtins during expanding.

Currently, range checking for vget/vset have been implemented.

There may have a drawback of this implementation: we can't get exact source location of caller after inlining, which are real common in `riscv_vector.h`.

```
In file included from rvv-vget-vset.c:3:
riscv_vector.h: In function 'vget':
riscv_vector.h:264:1: error: index 2 is out of range, should be less than 2.
  264 | _RVV_INT_WLMUL_ITERATOR (_RVVINT_VECTOR_EXTRACT)
      | ^~~~~~~~~~~~~~~~~~~~~~~
```
