### PR TITLE
Bugfix for register overlap

### DIFF
--- a/gcc/config/riscv/vector.md
+++ b/gcc/config/riscv/vector.md
@@ -8978,7 +8978,7 @@
 })
 
 (define_insn "*<fix_cvt><mode><vfwimode>2_mask_nosetvl"
-  [(set (match_operand:<VFWIMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VFWIMODE> 0 "register_operand" "=&vr")
 	(unspec:<VFWIMODE>
 	  [(if_then_else:<VFWIMODE>
 	     (match_operand:<VCMPEQUIV> 1 "register_operand" "vm")
@@ -9039,7 +9039,7 @@
 })
 
 (define_insn "*<fcvt_xf><mode><vfwimode>2_mask_nosetvl"
-  [(set (match_operand:<VFWIMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VFWIMODE> 0 "register_operand" "=&vr")
 	(unspec:<VFWIMODE>
 	  [(if_then_else:<VFWIMODE>
 	     (match_operand:<VCMPEQUIV> 1 "register_operand" "vm")
@@ -9098,7 +9098,7 @@
 })
 
 (define_insn "*<float_cvt><mode><viwfmode>2_mask_nosetvl"
-  [(set (match_operand:<VIWFMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VIWFMODE> 0 "register_operand" "=&vr")
 	(unspec:<VIWFMODE>
 	  [(if_then_else:<VIWFMODE>
 	     (match_operand:<VCMPEQUIV> 1 "register_operand" "vm")
@@ -9156,7 +9156,7 @@
 })
 
 (define_insn "*extend<mode><vwmode>2_mask_nosetvl"
-  [(set (match_operand:<VWMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VWMODE> 0 "register_operand" "=&vr")
 	(unspec:<VWMODE>
 	  [(if_then_else:<VWMODE>
 	     (match_operand:<VCMPEQUIV> 1 "register_operand" "vm")

--- a/gcc/config/riscv/vector.md
+++ b/gcc/config/riscv/vector.md
@@ -4225,7 +4225,7 @@
 })
 
 (define_insn "*fwmul<mode>_vv_mask_nosetvl"
-  [(set (match_operand:<VWMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VWMODE> 0 "register_operand" "=&vr")
 	(unspec:<VWMODE>
 	  [(if_then_else:<VWMODE>
 	     (match_operand:<VCMPEQUIV> 1 "register_operand" "vm")
@@ -4264,7 +4264,7 @@
 })
 
 (define_insn "*fwmul<mode>_vv_scalar_mask_nosetvl"
-  [(set (match_operand:<VWMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VWMODE> 0 "register_operand" "=&vr")
 	(unspec:<VWMODE>
 	  [(if_then_else:<VWMODE>
 	     (match_operand:<VCMPEQUIV> 1 "register_operand" "vm")
@@ -7536,7 +7536,7 @@
 })
 
 (define_insn "*wmul<u><mode>_mask_nosetvl"
-  [(set (match_operand:<VWMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VWMODE> 0 "register_operand" "=&vr")
 	(unspec:<VWMODE>
 	  [(if_then_else:<VWMODE>
 	     (match_operand:<VCMPEQUIV> 1 "register_operand" "vm")
@@ -7575,7 +7575,7 @@
 })
 
 (define_insn "*wmul<u><mode>_scalar_mask_nosetvl"
-  [(set (match_operand:<VWMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VWMODE> 0 "register_operand" "=&vr")
 	(unspec:<VWMODE>
 	  [(if_then_else:<VWMODE>
 	     (match_operand:<VCMPEQUIV> 1 "register_operand" "vm")
@@ -7682,7 +7682,7 @@
 })
 
 (define_insn "*wmulsu<mode>_mask_nosetvl"
-  [(set (match_operand:<VWMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VWMODE> 0 "register_operand" "=&vr")
 	(unspec:<VWMODE>
 	  [(if_then_else:<VWMODE>
 	     (match_operand:<VCMPEQUIV> 1 "register_operand" "vm")
@@ -7721,7 +7721,7 @@
 })
 
 (define_insn "*wmulsu<mode>_scalar_mask_nosetvl"
-  [(set (match_operand:<VWMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VWMODE> 0 "register_operand" "=&vr")
 	(unspec:<VWMODE>
 	  [(if_then_else:<VWMODE>
 	     (match_operand:<VCMPEQUIV> 1 "register_operand" "vm")

--- a/gcc/config/riscv/vector.md
+++ b/gcc/config/riscv/vector.md
@@ -3277,7 +3277,7 @@
 })
 
 (define_insn "*<sz_op>extend<mode><vewmode>2_mask_nosetvl"
-  [(set (match_operand:<VEWMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VEWMODE> 0 "register_operand" "=&vr")
 	(unspec:<VEWMODE>
 	  [(if_then_else:<VEWMODE>
 	     (match_operand:<VCMPEQUIV> 1 "register_operand" "vm")

--- a/gcc/config/riscv/vector.md
+++ b/gcc/config/riscv/vector.md
@@ -9216,7 +9216,7 @@
 })
 
 (define_insn "*<fix_cvt><viwfmode><mode>2_mask_nosetvl"
-  [(set (match_operand:FCVT_VWIMODES 0 "register_operand" "=vr")
+  [(set (match_operand:FCVT_VWIMODES 0 "register_operand" "=&vr")
 	(unspec:FCVT_VWIMODES
 	  [(if_then_else:FCVT_VWIMODES
 	     (match_operand:<VCMPEQUIV> 1 "register_operand" "vm")
@@ -9277,7 +9277,7 @@
 })
 
 (define_insn "*<fcvt_xf><viwfmode><mode>2_mask_nosetvl"
-  [(set (match_operand:FCVT_VWIMODES 0 "register_operand" "=vr")
+  [(set (match_operand:FCVT_VWIMODES 0 "register_operand" "=&vr")
 	(unspec:FCVT_VWIMODES
 	  [(if_then_else:FCVT_VWIMODES
 	     (match_operand:<VCMPEQUIV> 1 "register_operand" "vm")
@@ -9336,7 +9336,7 @@
 })
 
 (define_insn "*<float_cvt><vfwimode><mode>2_mask_nosetvl"
-  [(set (match_operand:VWFMODES 0 "register_operand" "=vr")
+  [(set (match_operand:VWFMODES 0 "register_operand" "=&vr")
 	(unspec:VWFMODES
 	  [(if_then_else:VWFMODES
 	     (match_operand:<VCMPEQUIV> 1 "register_operand" "vm")
@@ -9394,7 +9394,7 @@
 })
 
 (define_insn "*trunc<vwmode><mode>2_mask_nosetvl"
-  [(set (match_operand:VWFMODES 0 "register_operand" "=vr")
+  [(set (match_operand:VWFMODES 0 "register_operand" "=&vr")
 	(unspec:VWFMODES
 	  [(if_then_else:VWFMODES
 	     (match_operand:<VCMPEQUIV> 1 "register_operand" "vm")
@@ -9455,7 +9455,7 @@
 })
 
 (define_insn "*trunc_rod<vwmode><mode>2_mask_nosetvl"
-  [(set (match_operand:VWFMODES 0 "register_operand" "=vr")
+  [(set (match_operand:VWFMODES 0 "register_operand" "=&vr")
 	(unspec:VWFMODES
 	  [(if_then_else:VWFMODES
 	     (match_operand:<VCMPEQUIV> 1 "register_operand" "vm")

--- a/gcc/config/riscv/vector.md
+++ b/gcc/config/riscv/vector.md
@@ -6144,7 +6144,7 @@
 })
 
 (define_insn "*iota<mode>2_mask_nosetvl"
-  [(set (match_operand:VIMODES 0 "register_operand" "=vr")
+  [(set (match_operand:VIMODES 0 "register_operand" "=&vr")
 	(unspec:VIMODES
 	  [(unspec:VIMODES
 	     [(match_operand:<VCMPEQUIV> 1 "register_operand" "vm")

--- a/gcc/config/riscv/vector.md
+++ b/gcc/config/riscv/vector.md
@@ -6551,7 +6551,7 @@
 })
 
 (define_insn "*wreduc_sum<sumu><mode>_mask_nosetvl"
-  [(set (match_operand:<VW1MODES> 0 "register_operand" "=vr")
+  [(set (match_operand:<VW1MODES> 0 "register_operand" "=&vr")
 	(unspec:<VW1MODES>
 	  [(unspec:<VW1MODES>
 	     [(match_operand:<VCMPEQUIV> 1 "register_operand" "vm")
@@ -6769,7 +6769,7 @@
 })
 
 (define_insn "*wreduc_<order>sum<mode>_mask_nosetvl"
-  [(set (match_operand:<VW1MODES> 0 "register_operand" "=vr")
+  [(set (match_operand:<VW1MODES> 0 "register_operand" "=&vr")
 	(unspec:<VW1MODES>
 	  [(unspec:<VW1MODES>
 	    [(match_operand:<VCMPEQUIV> 1 "register_operand" "vm")

--- a/gcc/config/riscv/vector.md
+++ b/gcc/config/riscv/vector.md
@@ -3217,7 +3217,7 @@
 })
 
 (define_insn "*<sz_op>extend<mode><vqwmode>2_mask_nosetvl"
-  [(set (match_operand:<VQWMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VQWMODE> 0 "register_operand" "=&vr")
 	(unspec:<VQWMODE>
 	  [(if_then_else:<VQWMODE>
 	     (match_operand:<VCMPEQUIV> 1 "register_operand" "vm")

--- a/gcc/config/riscv/vector.md
+++ b/gcc/config/riscv/vector.md
@@ -4952,7 +4952,7 @@
 })
 
 (define_insn "*vfw<vfmac><mode>_mask_nosetvl"
-  [(set (match_operand:<VWMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VWMODE> 0 "register_operand" "=&vr")
 	(unspec:<VWMODE>
 	  [(unspec:<VWMODE>
 	     [(match_operand:<VCMPEQUIV> 1 "register_operand" "vm")
@@ -4995,7 +4995,7 @@
 })
 
 (define_insn "*vfw<vfmac><mode>_scalar_mask_nosetvl"
-  [(set (match_operand:<VWMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VWMODE> 0 "register_operand" "=&vr")
 	(unspec:<VWMODE>
 	  [(unspec:<VWMODE>
 	     [(match_operand:<VCMPEQUIV> 1 "register_operand" "vm")
@@ -8155,7 +8155,7 @@
 })
 
 (define_insn "*<u>madd<mode><vwmode>4_mask_nosetvl"
-  [(set (match_operand:<VWMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VWMODE> 0 "register_operand" "=&vr")
 	(unspec:<VWMODE>
 	  [(unspec:<VWMODE>
 	     [(match_operand:<VCMPEQUIV> 1 "register_operand" "vm")
@@ -8197,7 +8197,7 @@
 })
 
 (define_insn "*sumadd<mode><vwmode>4_mask_nosetvl"
-  [(set (match_operand:<VWMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VWMODE> 0 "register_operand" "=&vr")
 	(unspec:<VWMODE>
 	  [(unspec:<VWMODE>
 	     [(match_operand:<VCMPEQUIV> 1 "register_operand" "vm")
@@ -8240,7 +8240,7 @@
 })
 
 (define_insn "*<u>madd<mode><vwmode>4_scalar_mask_nosetvl"
-  [(set (match_operand:<VWMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VWMODE> 0 "register_operand" "=&vr")
 	(unspec:<VWMODE>
 	  [(unspec:<VWMODE>
 	     [(match_operand:<VCMPEQUIV> 1 "register_operand" "vm")
@@ -8284,7 +8284,7 @@
 })
 
 (define_insn "*sumadd<mode><vwmode>4_scalar_mask_nosetvl"
-  [(set (match_operand:<VWMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VWMODE> 0 "register_operand" "=&vr")
 	(unspec:<VWMODE>
 	  [(unspec:<VWMODE>
 	     [(match_operand:<VCMPEQUIV> 1 "register_operand" "vm")
@@ -8328,7 +8328,7 @@
 })
 
 (define_insn "*usmadd<mode><vwmode>4_scalar_mask_nosetvl"
-  [(set (match_operand:<VWMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VWMODE> 0 "register_operand" "=&vr")
 	(unspec:<VWMODE>
 	  [(unspec:<VWMODE>
 	     [(match_operand:<VCMPEQUIV> 1 "register_operand" "vm")

--- a/gcc/config/riscv/vector.md
+++ b/gcc/config/riscv/vector.md
@@ -7069,7 +7069,7 @@
 })
 
 (define_insn "*<vnshift><mode>3_nv_mask_nosetvl"
-  [(set (match_operand:VWIMODES 0 "register_operand" "=vr,vr")
+  [(set (match_operand:VWIMODES 0 "register_operand" "=&vr,&vr")
 	(unspec:VWIMODES
 	  [(if_then_else:VWIMODES
 	     (match_operand:<VCMPEQUIV> 1 "register_operand" "vm,vm")
@@ -7108,7 +7108,7 @@
 })
 
 (define_insn "*<vnshift><mode>3_scalar_nv_mask_nosetvl"
-  [(set (match_operand:VWIMODES 0 "register_operand" "=vr")
+  [(set (match_operand:VWIMODES 0 "register_operand" "=&vr")
 	(unspec:VWIMODES
 	  [(if_then_else:VWIMODES
 	     (match_operand:<VCMPEQUIV> 1 "register_operand" "vm")
@@ -7169,7 +7169,7 @@
 })
 
 (define_insn "*vncvt<mode>3_mask_nosetvl"
-  [(set (match_operand:VWIMODES 0 "register_operand" "=vr,vr")
+  [(set (match_operand:VWIMODES 0 "register_operand" "=&vr,&vr")
 	(unspec:VWIMODES
 	  [(if_then_else:VWIMODES
 	     (match_operand:<VCMPEQUIV> 1 "register_operand" "vm,vm")

--- a/gcc/config/riscv/vector.md
+++ b/gcc/config/riscv/vector.md
@@ -10072,7 +10072,7 @@
 })
 
 (define_insn "*vnclip<v_su><mode>3_nv_mask_nosetvl"
-  [(set (match_operand:VWIMODES 0 "register_operand" "=vr,vr")
+  [(set (match_operand:VWIMODES 0 "register_operand" "=&vr,&vr")
 	(unspec:VWIMODES
 	  [(if_then_else:VWIMODES
 	     (match_operand:<VCMPEQUIV> 1 "register_operand" "vm,vm")
@@ -10111,7 +10111,7 @@
 })
 
 (define_insn "*vnclip<v_su><mode>3_scalar_nv_mask_nosetvl"
-  [(set (match_operand:VWIMODES 0 "register_operand" "=vr")
+  [(set (match_operand:VWIMODES 0 "register_operand" "=&vr")
 	(unspec:VWIMODES
 	  [(if_then_else:VWIMODES
 	     (match_operand:<VCMPEQUIV> 1 "register_operand" "vm")

--- a/gcc/config/riscv/vector.md
+++ b/gcc/config/riscv/vector.md
@@ -2860,7 +2860,7 @@
 })
 
 (define_insn "*w<add_sub:optab><any_extend:u><mode>_vv_mask_nosetvl"
-  [(set (match_operand:<VWMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VWMODE> 0 "register_operand" "=&vr")
 	(unspec:<VWMODE>
 	  [(if_then_else:<VWMODE>
 	     (match_operand:<VCMPEQUIV> 1 "register_operand" "vm")
@@ -2899,7 +2899,7 @@
 })
 
 (define_insn "*w<add_sub:optab><any_extend:u><mode>_vv_scalar_mask_nosetvl"
-  [(set (match_operand:<VWMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VWMODE> 0 "register_operand" "=&vr")
 	(unspec:<VWMODE>
 	  [(if_then_else:<VWMODE>
 	     (match_operand:<VCMPEQUIV> 1 "register_operand" "vm")
@@ -2965,7 +2965,7 @@
 })
 
 (define_insn "*w<add_sub:optab><any_extend:u><mode>_wv_scalar_nosetvl"
-  [(set (match_operand:<VWMODE> 0 "register_operand" "=&vr")
+  [(set (match_operand:<VWMODE> 0 "register_operand" "=vr")
 	(unspec:<VWMODE>
 	  [(add_sub:<VWMODE>
 	     (match_operand:<VWMODE> 1 "register_operand" "vr")
@@ -2999,7 +2999,7 @@
 })
 
 (define_insn "*w<add_sub:optab><any_extend:u><mode>_wv_mask_nosetvl"
-  [(set (match_operand:<VWMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VWMODE> 0 "register_operand" "=&vr")
 	(unspec:<VWMODE>
 	  [(if_then_else:<VWMODE>
 	     (match_operand:<VCMPEQUIV> 1 "register_operand" "vm")
@@ -3380,7 +3380,7 @@
 })
 
 (define_insn "*fw<optab><mode>_vv_mask_nosetvl"
-  [(set (match_operand:<VWMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VWMODE> 0 "register_operand" "=&vr")
 	(unspec:<VWMODE>
 	  [(if_then_else:<VWMODE>
 	     (match_operand:<VCMPEQUIV> 1 "register_operand" "vm")
@@ -3419,7 +3419,7 @@
 })
 
 (define_insn "*fw<optab><mode>_vv_scalar_mask_nosetvl"
-  [(set (match_operand:<VWMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VWMODE> 0 "register_operand" "=&vr")
 	(unspec:<VWMODE>
 	  [(if_then_else:<VWMODE>
 	     (match_operand:<VCMPEQUIV> 1 "register_operand" "vm")
@@ -3485,7 +3485,7 @@
 })
 
 (define_insn "*fw<optab><mode>_wv_scalar_nosetvl"
-  [(set (match_operand:<VWMODE> 0 "register_operand" "=&vr")
+  [(set (match_operand:<VWMODE> 0 "register_operand" "=vr")
 	(unspec:<VWMODE>
 	  [(add_sub:<VWMODE>
 	     (match_operand:<VWMODE> 1 "register_operand" "vr")
@@ -3519,7 +3519,7 @@
 })
 
 (define_insn "*fw<optab><mode>_wv_mask_nosetvl"
-  [(set (match_operand:<VWMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VWMODE> 0 "register_operand" "=&vr")
 	(unspec:<VWMODE>
 	  [(if_then_else:<VWMODE>
 	     (match_operand:<VCMPEQUIV> 1 "register_operand" "vm")

--- a/gcc/config/riscv/vector.md
+++ b/gcc/config/riscv/vector.md
@@ -8559,7 +8559,7 @@
 })
 
 (define_insn "*<u>madd<mode><vqwmode>4_mask_nosetvl"
-  [(set (match_operand:<VQWMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VQWMODE> 0 "register_operand" "=&vr")
 	(unspec:<VQWMODE>
 	  [(unspec:<VQWMODE>
 	     [(match_operand:<VCMPEQUIV> 1 "register_operand" "vm")
@@ -8601,7 +8601,7 @@
 })
 
 (define_insn "*sumadd<mode><vqwmode>4_mask_nosetvl"
-  [(set (match_operand:<VQWMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VQWMODE> 0 "register_operand" "=&vr")
 	(unspec:<VQWMODE>
 	  [(unspec:<VQWMODE>
 	     [(match_operand:<VCMPEQUIV> 1 "register_operand" "vm")
@@ -8644,7 +8644,7 @@
 })
 
 (define_insn "*<u>madd<mode><vqwmode>4_scalar_mask_nosetvl"
-  [(set (match_operand:<VQWMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VQWMODE> 0 "register_operand" "=&vr")
 	(unspec:<VQWMODE>
 	  [(unspec:<VQWMODE>
 	     [(match_operand:<VCMPEQUIV> 1 "register_operand" "vm")
@@ -8688,7 +8688,7 @@
 })
 
 (define_insn "*sumadd<mode><vqwmode>4_scalar_mask_nosetvl"
-  [(set (match_operand:<VQWMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VQWMODE> 0 "register_operand" "=&vr")
 	(unspec:<VQWMODE>
 	  [(unspec:<VQWMODE>
 	     [(match_operand:<VCMPEQUIV> 1 "register_operand" "vm")
@@ -8732,7 +8732,7 @@
 })
 
 (define_insn "*usmadd<mode><vqwmode>4_scalar_mask_nosetvl"
-  [(set (match_operand:<VQWMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VQWMODE> 0 "register_operand" "=&vr")
 	(unspec:<VQWMODE>
 	  [(unspec:<VQWMODE>
 	     [(match_operand:<VCMPEQUIV> 1 "register_operand" "vm")

--- a/gcc/config/riscv/vector.md
+++ b/gcc/config/riscv/vector.md
@@ -680,7 +680,7 @@
 })
 
 (define_insn "*vloxei<VMODES:mode><VIMODES:mode>_<P:mode>_mask_nosetvl"
-  [(set (match_operand:VMODES 0 "register_operand" "=vr")
+  [(set (match_operand:VMODES 0 "register_operand" "=&vr")
 	(unspec:VMODES
 	  [(unspec:VMODES
 	     [(match_operand:<VMODES:VCMPEQUIV> 1 "register_operand" "vm")
@@ -756,7 +756,7 @@
 })
 
 (define_insn "*vluxei<VMODES:mode><VIMODES:mode>_<P:mode>_mask_nosetvl"
-  [(set (match_operand:VMODES 0 "register_operand" "=vr")
+  [(set (match_operand:VMODES 0 "register_operand" "=&vr")
 	(unspec:VMODES
 	  [(unspec:VMODES
 	     [(match_operand:<VMODES:VCMPEQUIV> 1 "register_operand" "vm")

--- a/gcc/config/riscv/vector.md
+++ b/gcc/config/riscv/vector.md
@@ -3157,7 +3157,7 @@
 })
 
 (define_insn "*<sz_op>extend<mode><vwmode>2_mask_nosetvl"
-  [(set (match_operand:<VWMODE> 0 "register_operand" "=vr")
+  [(set (match_operand:<VWMODE> 0 "register_operand" "=&vr")
 	(unspec:<VWMODE>
 	  [(if_then_else:<VWMODE>
 	     (match_operand:<VCMPEQUIV> 1 "register_operand" "vm")


### PR DESCRIPTION
I have checked all instructions, mainly reference the vector spec here: 

https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#sec-vec-operands

