### PR TITLE
analyzer: Fix tests for glibc 2.35 [PR101081]

### DIFF
--- a/gcc/testsuite/gcc.dg/analyzer/analyzer-verbosity-2a.c
+++ b/gcc/testsuite/gcc.dg/analyzer/analyzer-verbosity-2a.c
@@ -1,6 +1,9 @@
 /* { dg-additional-options "-fanalyzer-verbosity=2" } */
 
-#include <stdio.h>
+typedef struct FILE   FILE;
+
+FILE* fopen (const char*, const char*);
+int   fclose (FILE*);
 
 extern int foo ();
 extern void bar ();

--- a/gcc/testsuite/gcc.dg/analyzer/analyzer-verbosity-3a.c
+++ b/gcc/testsuite/gcc.dg/analyzer/analyzer-verbosity-3a.c
@@ -1,6 +1,9 @@
 /* { dg-additional-options "-fanalyzer-verbosity=3" } */
 
-#include <stdio.h>
+typedef struct FILE   FILE;
+
+FILE* fopen (const char*, const char*);
+int   fclose (FILE*);
 
 extern int foo ();
 extern void bar ();

--- a/gcc/testsuite/gcc.dg/analyzer/edges-1.c
+++ b/gcc/testsuite/gcc.dg/analyzer/edges-1.c
@@ -1,4 +1,7 @@
-#include <stdio.h>
+typedef struct FILE   FILE;
+
+FILE* fopen (const char*, const char*);
+int   fclose (FILE*);
 
 extern int foo ();
 extern void bar ();

--- a/gcc/testsuite/gcc.dg/analyzer/file-1.c
+++ b/gcc/testsuite/gcc.dg/analyzer/file-1.c
@@ -1,4 +1,9 @@
-#include <stdio.h>
+typedef struct FILE   FILE;
+
+FILE* fopen (const char*, const char*);
+int   fclose (FILE*);
+#define SEEK_SET        0
+int fseek (FILE *, long int, int);
 
 void
 test_1 (const char *path)

--- a/gcc/testsuite/gcc.dg/analyzer/file-2.c
+++ b/gcc/testsuite/gcc.dg/analyzer/file-2.c
@@ -1,4 +1,7 @@
-#include <stdio.h>
+typedef struct FILE   FILE;
+
+FILE* fopen (const char*, const char*);
+int   fclose (FILE*);
 
 struct foo
 {

--- a/gcc/testsuite/gcc.dg/analyzer/file-paths-1.c
+++ b/gcc/testsuite/gcc.dg/analyzer/file-paths-1.c
@@ -1,6 +1,13 @@
 /* { dg-additional-options "-fanalyzer-verbosity=3" } */
 
-#include <stdio.h>
+typedef struct FILE   FILE;
+
+FILE* fopen (const char*, const char*);
+int   fclose (FILE*);
+char *fgets (char *, int, FILE *);
+
+#define NULL ((void *)0)
+
 
 /* Verify that we correctly emit CFG events in the face of buffers
    being clobbered in these leak reports.  */

--- a/gcc/testsuite/gcc.dg/analyzer/file-pr58237.c
+++ b/gcc/testsuite/gcc.dg/analyzer/file-pr58237.c
@@ -1,4 +1,10 @@
-#include <stdio.h>
+typedef struct FILE   FILE;
+
+FILE* fopen (const char*, const char*);
+int   fclose (FILE*);
+char *fgets (char *, int, FILE *);
+
+#define NULL ((void *)0)
 
 void f0(const char *str)
 {

--- a/gcc/testsuite/gcc.dg/analyzer/pr99716-1.c
+++ b/gcc/testsuite/gcc.dg/analyzer/pr99716-1.c
@@ -1,5 +1,10 @@
-#include <stdio.h>
-#include <stdlib.h>
+typedef struct FILE   FILE;
+
+FILE* fopen (const char*, const char*);
+int   fclose (FILE*);
+int fprintf (FILE *, const char *, ...);
+
+#define NULL ((void *)0)
 
 void
 test_1 (void)


### PR DESCRIPTION
I haven't actually tested this one yet, but it very much smells like it'll fix the new failures I'm running into when trying to update glibc.  I'll comment further when the tests finish, but I've got to go run the beer hour (which is more like 3 hours) now so I figured I'd open this preemptively.