### PR TITLE
Backport testsuite: Remove an xfail.

### DIFF
--- a/gcc/testsuite/gcc.dg/Wstringop-overflow-43.c
+++ b/gcc/testsuite/gcc.dg/Wstringop-overflow-43.c
@@ -167,9 +167,7 @@ void warn_memset_reversed_range (void)
   /* The following are represented as ordinary ranges with reversed bounds
      and those are handled. */
   T1 (p, SAR (INT_MIN,  11), n11);      // { dg-warning "writing 11 or more bytes into a region of size 0" }
-  /* In ILP32 the offset in the following has no range info associated
-     with it.  */
-  T1 (p, SAR (INT_MIN,   1), n11);      // { dg-warning "writing 11 or more bytes into a region of size 0" "pr?????" { xfail ilp32 } }
+  T1 (p, SAR (INT_MIN,   1), n11);      // { dg-warning "writing 11 or more bytes into a region of size 0" }
   T1 (p, SAR (INT_MIN,   0), n11);      // { dg-warning "writing 11 or more bytes into a region of size 0" }
   /* Also represented as a true anti-range.  */
   T1 (p, SAR (    -12, -11), n11);      // { dg-warning "writing 11 or more bytes into a region of size \\d+" }


### PR DESCRIPTION
This fixes https://github.com/riscv-collab/riscv-gnu-toolchain/issues/1031 for me.