### PR TITLE
Riscv gcc 12.1.0 Fix arch canonicalize

### DIFF
--- a/gcc/config/riscv/arch-canonicalize
+++ b/gcc/config/riscv/arch-canonicalize
@@ -134,7 +134,7 @@ def arch_canonicalize(arch, isa_spec):
 
   # Put extensions in canonical order.
   for ext in CANONICAL_ORDER:
-    if ext in std_exts:
+    if ext in std_exts and ext not in new_arch:
       new_arch += ext
 
   # Check every extension is processed.


### PR DESCRIPTION
First time contributing - let me know if I'm doing anything wrong here.

4f015efba2a89acc6e078d3abf86e69d52932ddf seems to have broken arch-canonicalize for any arch that doesn't start with 'g'.
Example:
```
$ ./arch-canonicalize rv32imc
rv32imafdc_zicsr
```

This PR reverts that commit and fixes what 4f015efba2a89acc6e078d3abf86e69d52932ddf was trying to do.