### PR TITLE
RISC-V: Refine mov<tuple mode> pattern

### DIFF
--- a/gcc/config/riscv/vector.md
+++ b/gcc/config/riscv/vector.md
@@ -196,9 +196,7 @@
 (define_expand "mov<mode>"
   [(parallel [(set (match_operand:VT 0 "reg_or_mem_operand")
                    (match_operand:VT 1 "vector_move_operand"))
-     (clobber (match_scratch:QI 2))
-     (clobber (match_scratch:QI 3))
-     (clobber (match_scratch:QI 4))])]
+     (clobber (match_scratch:QI 2))])]
   "TARGET_VECTOR"
   {
     /* Need to force register if mem <- !reg.  */
@@ -215,9 +213,7 @@
 (define_insn_and_split "*mov<mode>"
   [(set (match_operand:VT 0 "reg_or_mem_operand" "=vr,vr, m")
         (match_operand:VT 1 "reg_or_mem_operand"  " vr, m,vr"))
-   (clobber (match_scratch:QI 2 "=X,&r,&r"))
-   (clobber (match_scratch:QI 3 "=X,&r,&r"))
-   (clobber (match_scratch:QI 4 "=X,&r,&r"))]
+   (clobber (match_scratch:QI 2 "=X,&r,&r"))]
   "TARGET_VECTOR"
   "#"
   "&& reload_completed"


### PR DESCRIPTION
Hi, @zhongjuzhe .
Consider this following code:

`#include <riscv_vector.h>`
`vint8mf8x8_t`
`test_vlseg8e8_v_i8mf8x8 (int8_t *base, size_t vl)`
`{`
     `vint8mf8x8_t res = vlseg8e8_v_i8mf8x8 (base, vl);`
     `return res;`
`}`

-mriscv-vector-bits = 128
Before this patch:
`test_vlseg8e8_v_i8mf8x8:`
  `addi  sp,sp,-48`
 ` sd  s0,40(sp)`
 ` addi  s0,sp,48`
 ` sd  a0,-40(s0)`
 ` sd  a1,-48(s0)`
 ` ld  a5,-40(s0)`
  `ld  a4,-48(s0)`
  `vsetvli  zero,a4,e8,mf8,ta,mu`
 ` vlseg8e8.v  v24,(a5)`
 ` addi  a5,s0,-32`
  **`mv  a3,a5`
  `vsetvli  a2,zero,e8,mf8,ta,mu`
  `vse8.v  v24,(a3)`
  `addi  a3,a3,2`
 ` vse8.v  v25,(a3)`
  `addi  a3,a3,2`
  `vse8.v  v26,(a3)`
  `addi  a3,a3,2`
  `vse8.v  v27,(a3)`
  `addi  a3,a3,2`
  `vse8.v  v28,(a3)`
  `addi  a3,a3,2`
  `vse8.v  v29,(a3)`
 ` addi  a3,a3,2`
  `vse8.v  v30,(a3)`
  `addi  a3,a3,2`
  `vse8.v  v31,(a3)`**
  `addi  a5,s0,-32`
  **`mv  a3,a5`
  `vle8.v  v24,(a3)`
  `addi  a3,a3,2`
  `vle8.v  v25,(a3)`
  `addi  a3,a3,2`
 ` vle8.v  v26,(a3)`
 ` addi  a3,a3,2`
  `vle8.v  v27,(a3)`
  `addi  a3,a3,2`
  `vle8.v  v28,(a3)`
  `addi  a3,a3,2`
  `vle8.v  v29,(a3)`
  `addi  a3,a3,2`
  `vle8.v  v30,(a3)`
  `addi  a3,a3,2`
  `vle8.v  v31,(a3)`**
  `vmv1r.v  v8,v24`
  `vmv1r.v  v9,v25`
 ` vmv1r.v  v10,v26`
  `vmv1r.v  v11,v27`
 ` vmv1r.v  v12,v28`
  `vmv1r.v  v13,v29`
 ` vmv1r.v  v14,v30`
  `vmv1r.v  v15,v31`
 ` ld  s0,40(sp)`
 ` addi  sp,sp,48`
  `jr  ra`

Currently we need to loop NF times to expand the vector tuple mode,  which will generate redundant load/store instructions. 
Actually we can use segment load/store instruction under  (REG_P (ops[0]) && MEM_P (ops[1])) or (MEM_P (ops[0]) && REG_P (ops[1])) condition.

After this patch:
`test_vlseg8e8_v_i8mf8x8:`
  `addi  sp,sp,-48`
 ` sd  s0,40(sp)`
 ` addi  s0,sp,48`
  `sd  a0,-40(s0)`
 ` sd  a1,-48(s0)`
  `ld  a5,-40(s0)`
  `ld  a4,-48(s0)`
  `vsetvli  zero,a4,e8,mf8,ta,mu`
 ` vlseg8e8.v  v24,(a5)`
  `addi  a5,s0,-32`
  **`vsetvli  a4,zero,e8,mf8,ta,mu`
  `vsseg8e8.v  v24,(a5)`**
  `addi  a5,s0,-32`
  **`vlseg8e8.v  v24,(a5)`**
  `vmv1r.v  v8,v24`
  `vmv1r.v  v9,v25`
  `vmv1r.v  v10,v26`
  `vmv1r.v  v11,v27`
  `vmv1r.v  v12,v28`
  `vmv1r.v  v13,v29`
  `vmv1r.v  v14,v30`
  `vmv1r.v  v15,v31`
 ` ld  s0,40(sp)`
  `addi  sp,sp,48`
  `jr  ra`

Is this okay?