### PR TITLE
RISCV: Add vector psabi checking.

### DIFF
--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -3790,8 +3790,9 @@ riscv_pass_in_vector_p (const_tree type)
 
   if (type && riscv_arg_has_vector (type) && !warned)
     {
-      warning (OPT_Wpsabi, "ABI for the vector type is currently in experimental"
-	       "stage and may changes in the upcoming version of GCC.");
+      warning (OPT_Wpsabi, "ABI for the vector type is currently in "
+	       "experimental stage and may changes in the upcoming version of "
+	       "GCC.");
       warned = 1;
     }
 }

--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -3736,10 +3736,10 @@ riscv_scalable_vector_type_p (const_tree type)
 {
   tree size = TYPE_SIZE (type);
   if (size && TREE_CODE (size) == INTEGER_CST)
-    return true;
+    return false;
 
   /* For the data type like vint32m1_t, the size code is POLY_INT_CST.  */
-  return false;
+  return true;
 }
 
 static bool
@@ -3762,7 +3762,7 @@ riscv_arg_has_vector (const_tree type)
 
 	    /* Ignore it if it's fixed length vector.  */
 	    if (VECTOR_TYPE_P (field_type))
-	      is_vector = !riscv_scalable_vector_type_p (field_type);
+	      is_vector = riscv_scalable_vector_type_p (field_type);
 	    else
 	      is_vector = riscv_arg_has_vector (field_type);
 	  }
@@ -3770,7 +3770,7 @@ riscv_arg_has_vector (const_tree type)
       break;
 
     case VECTOR_TYPE:
-      is_vector = !riscv_scalable_vector_type_p (type);
+      is_vector = riscv_scalable_vector_type_p (type);
       break;
 
     default:
@@ -3791,7 +3791,7 @@ riscv_pass_in_vector_p (const_tree type)
 
   if (type && riscv_arg_has_vector (type) && !warned)
     {
-      warning (OPT_Wpsabi, "ABI for the vector type is currently in "
+      warning (OPT_Wpsabi, "ABI for the scalable vector type is currently in "
 	       "experimental stage and may changes in the upcoming version of "
 	       "GCC.");
       warned = 1;

--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -3732,10 +3732,10 @@ riscv_pass_fpr_pair (machine_mode mode, unsigned regno1,
    intrinsic vector type.  Because we can't get the decl for the params.  */
 
 static bool
-riscv_arg_has_vector_size_attribute(const_tree type)
+riscv_arg_has_vector_size_attribute (const_tree type)
 {
-  tree size = TYPE_SIZE(type);
-  if (size && TREE_CODE(size) == INTEGER_CST)
+  tree size = TYPE_SIZE (type);
+  if (size && TREE_CODE (size) == INTEGER_CST)
     return true;
 
   /* For the data type like vint32m1_t, the size code is POLY_INT_CST.  */

--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -3732,7 +3732,7 @@ riscv_pass_fpr_pair (machine_mode mode, unsigned regno1,
    intrinsic vector type.  Because we can't get the decl for the params.  */
 
 static bool
-riscv_arg_has_vector_size_attribute (const_tree type)
+riscv_scalable_vector_type_p (const_tree type)
 {
   tree size = TYPE_SIZE (type);
   if (size && TREE_CODE (size) == INTEGER_CST)
@@ -3756,20 +3756,21 @@ riscv_arg_has_vector (const_tree type)
       for (tree f = TYPE_FIELDS (type); f; f = DECL_CHAIN (f))
 	if (TREE_CODE (f) == FIELD_DECL)
 	  {
-	    if (!TYPE_P (TREE_TYPE (f)))
+	    tree field_type = TREE_TYPE (f);
+	    if (!TYPE_P (field_type))
 	      break;
 
-	    /* If there's vector_size attribute, ignore it.  */
-	    if (VECTOR_TYPE_P (TREE_TYPE (f)))
-	      is_vector = !riscv_arg_has_vector_size_attribute (type);
+	    /* Ignore it if it's fixed length vector.  */
+	    if (VECTOR_TYPE_P (field_type))
+	      is_vector = !riscv_scalable_vector_type_p (field_type);
 	    else
-	      is_vector = riscv_arg_has_vector (TREE_TYPE (f));
+	      is_vector = riscv_arg_has_vector (field_type);
 	  }
 
       break;
 
     case VECTOR_TYPE:
-      is_vector = !riscv_arg_has_vector_size_attribute (type);
+      is_vector = !riscv_scalable_vector_type_p (type);
       break;
 
     default:

--- a/gcc/config/riscv/riscv.h
+++ b/gcc/config/riscv/riscv.h
@@ -671,14 +671,18 @@ typedef struct {
 
   /* Number of floating-point registers used so far, likewise.  */
   unsigned int num_fprs;
+
+  bool rvv_psabi_warning;
 } CUMULATIVE_ARGS;
 
 /* Initialize a variable CUM of type CUMULATIVE_ARGS
    for a call to a function whose data type is FNTYPE.
    For a library call, FNTYPE is 0.  */
 
+void init_cumulative_args (CUMULATIVE_ARGS *, tree, rtx, tree, int);
 #define INIT_CUMULATIVE_ARGS(CUM, FNTYPE, LIBNAME, INDIRECT, N_NAMED_ARGS) \
-  memset (&(CUM), 0, sizeof (CUM))
+  init_cumulative_args (&(CUM), (FNTYPE), (LIBNAME), (INDIRECT), \
+			(N_NAMED_ARGS) != -1)
 
 #define EPILOGUE_USES(REGNO)	riscv_epilogue_uses (REGNO)
 

--- a/gcc/testsuite/gcc.target/riscv/vector-abi-1.c
+++ b/gcc/testsuite/gcc.target/riscv/vector-abi-1.c
@@ -1,0 +1,14 @@
+/* { dg-do compile } */
+/* { dg-options "-O0 -march=rv64gcv -mabi=lp64d" } */
+
+#include "riscv_vector.h"
+
+void
+fun (vint32m1_t a) { } /* { dg-warning "the vector type" } */
+
+void
+bar ()
+{
+  vint32m1_t a;
+  fun (a);
+}

--- a/gcc/testsuite/gcc.target/riscv/vector-abi-2.c
+++ b/gcc/testsuite/gcc.target/riscv/vector-abi-2.c
@@ -1,0 +1,14 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv64gcv -mabi=lp64d" } */
+
+#include "riscv_vector.h"
+
+vint32m1_t
+fun (vint32m1_t* a) {  return *a; }  /* { dg-warning "the vector type" } */
+
+void
+bar ()
+{
+  vint32m1_t a;
+  fun (&a);
+}

--- a/gcc/testsuite/gcc.target/riscv/vector-abi-3.c
+++ b/gcc/testsuite/gcc.target/riscv/vector-abi-3.c
@@ -1,0 +1,14 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv64gcv -mabi=lp64d" } */
+
+#include "riscv_vector.h"
+
+vint32m1_t*
+fun (vint32m1_t* a) {  return a; }  /* { dg-bogus "the vector type" } */
+
+void
+bar ()
+{
+  vint32m1_t a;
+  fun (&a);
+}

--- a/gcc/testsuite/gcc.target/riscv/vector-abi-4.c
+++ b/gcc/testsuite/gcc.target/riscv/vector-abi-4.c
@@ -1,0 +1,16 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv64gcv -mabi=lp64d" } */
+
+#include "riscv_vector.h"
+
+typedef int v4si __attribute__ ((vector_size (16)));
+
+v4si
+fun (v4si a) {  return a; }  /* { dg-warning "the vector type" } */
+
+void
+bar ()
+{
+  v4si a;
+  fun (a);
+}

--- a/gcc/testsuite/gcc.target/riscv/vector-abi-4.c
+++ b/gcc/testsuite/gcc.target/riscv/vector-abi-4.c
@@ -6,7 +6,7 @@
 typedef int v4si __attribute__ ((vector_size (16)));
 
 v4si
-fun (v4si a) {  return a; }  /* { dg-warning "the vector type" } */
+fun (v4si a) {  return a; }  /* { dg-bogus "the vector type" } */
 
 void
 bar ()

--- a/gcc/testsuite/gcc.target/riscv/vector-abi-5.c
+++ b/gcc/testsuite/gcc.target/riscv/vector-abi-5.c
@@ -1,15 +1,15 @@
 /* { dg-do compile } */
 /* { dg-options "-march=rv64gcv -mabi=lp64d" } */
 
-#include "riscv_vector.h"
 typedef int v4si __attribute__ ((vector_size (16)));
+struct A { int a; v4si b; };
 
-v4si*
-fun (v4si* a) {  return a; }  /* { dg-bogus "the vector type" } */
+void
+fun (struct A a) {} /* { dg-bogus "the vector type" } */
 
 void
 bar ()
 {
-  v4si a;
-  fun (&a);
+  struct A a;
+  fun (a);
 }

--- a/gcc/testsuite/gcc.target/riscv/vector-abi-5.c
+++ b/gcc/testsuite/gcc.target/riscv/vector-abi-5.c
@@ -1,0 +1,15 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv64gcv -mabi=lp64d" } */
+
+#include "riscv_vector.h"
+typedef int v4si __attribute__ ((vector_size (16)));
+
+v4si*
+fun (v4si* a) {  return a; }  /* { dg-bogus "the vector type" } */
+
+void
+bar ()
+{
+  v4si a;
+  fun (&a);
+}


### PR DESCRIPTION
This patch adds support to check function's argument or return is vector type and throw warning.

gcc/ChangeLog:

	* config/riscv/riscv.cc (riscv_legitimize_move): (riscv_vector_psabi_warnning): (riscv_arg_has_vector): (riscv_pass_in_vector_p): (riscv_get_arg_info):

gcc/testsuite/ChangeLog:

	* gcc.target/riscv/vector-abi-1.c: New test.
	* gcc.target/riscv/vector-abi-2.c: New test.